### PR TITLE
fix: return from Run

### DIFF
--- a/engine/engine_impl.go
+++ b/engine/engine_impl.go
@@ -236,7 +236,7 @@ func (k *Kubernetes) Run(ctx context.Context, specv runtime.Spec, stepv runtime.
 		retries++
 
 		if err != nil && retries >= 5 {
-			return nil, err
+			break
 		}
 
 		<-time.After(time.Second * 5)


### PR DESCRIPTION
Maybe we don't want to actually exit Run function before the cleanup step.